### PR TITLE
#6: Support operationId for event name

### DIFF
--- a/modules/vertx-swagger-router/src/main/java/io/vertx/ext/swagger/router/DefaultServiceIdResolver.java
+++ b/modules/vertx-swagger-router/src/main/java/io/vertx/ext/swagger/router/DefaultServiceIdResolver.java
@@ -1,0 +1,26 @@
+package io.vertx.ext.swagger.router;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.models.Operation;
+
+/**
+ * Default implementation of {@link ServiceIdResolver} which generates service ID by concatenating HTTP verb and endpoint path.
+ *
+ * <p>Example:
+ *
+ * <p>Endpoint for the operation
+ *
+ * <pre>POST /withGeneratedServiceId/{param1}/and/path</pre>
+ *
+ * is converted to service ID
+ *
+ * <pre>POST_withGeneratedServiceId_param1_and_path</pre>
+ *
+ * @since 12/02/2017.
+ */
+public class DefaultServiceIdResolver implements ServiceIdResolver {
+    @Override
+    public String resolve(HttpMethod httpMethod, String pathname, Operation operation) {
+        return httpMethod.name() + pathname.replaceAll("-", "_").replaceAll("/", "_").replaceAll("[{}]", "");
+    }
+}

--- a/modules/vertx-swagger-router/src/main/java/io/vertx/ext/swagger/router/OperationIdServiceIdResolver.java
+++ b/modules/vertx-swagger-router/src/main/java/io/vertx/ext/swagger/router/OperationIdServiceIdResolver.java
@@ -1,0 +1,22 @@
+package io.vertx.ext.swagger.router;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.models.Operation;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Implementation of {@link ServiceIdResolver} which uses {@code operationId} property specified for an operation in Swagger file
+ * and falls back to {@link DefaultServiceIdResolver} if no operation ID specified.
+ *
+ * @since 12/02/2017.
+ */
+public class OperationIdServiceIdResolver extends DefaultServiceIdResolver {
+    @Override
+    public String resolve(HttpMethod httpMethod, String pathname, Operation operation) {
+        if (StringUtils.isBlank(operation.getOperationId())) {
+            return super.resolve(httpMethod, pathname, operation);
+        }
+
+        return operation.getOperationId();
+    }
+}

--- a/modules/vertx-swagger-router/src/main/java/io/vertx/ext/swagger/router/ServiceIdResolver.java
+++ b/modules/vertx-swagger-router/src/main/java/io/vertx/ext/swagger/router/ServiceIdResolver.java
@@ -1,0 +1,11 @@
+package io.vertx.ext.swagger.router;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.models.Operation;
+
+/**
+ * Created by inikolaev on 12/02/2017.
+ */
+public interface ServiceIdResolver {
+    String resolve(HttpMethod httpMethod, String pathname, Operation operation);
+}

--- a/modules/vertx-swagger-router/src/test/java/io/vertx/ext/swagger/router/BuildRouterTest.java
+++ b/modules/vertx-swagger-router/src/test/java/io/vertx/ext/swagger/router/BuildRouterTest.java
@@ -43,7 +43,7 @@ public class BuildRouterTest {
     private static HttpClient httpClient;
 
     @BeforeClass
-    public static void beforClass(TestContext context) {
+    public static void beforeClass(TestContext context) {
         Async before = context.async();
         vertx = Vertx.vertx();
         eventBus = vertx.eventBus();

--- a/modules/vertx-swagger-router/src/test/java/io/vertx/ext/swagger/router/ServiceIdResolverTest.java
+++ b/modules/vertx-swagger-router/src/test/java/io/vertx/ext/swagger/router/ServiceIdResolverTest.java
@@ -1,0 +1,52 @@
+package io.vertx.ext.swagger.router;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.models.Operation;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by inikolaev on 12/02/2017.
+ */
+public class ServiceIdResolverTest {
+    @Test
+    public void testDefaultResolver() {
+        final ServiceIdResolver resolver = new DefaultServiceIdResolver();
+        final String serviceId = resolver.resolve(HttpMethod.GET, "/some/path", new Operation());
+
+        assertEquals("GET_some_path", serviceId);
+    }
+
+    @Test
+    public void testDefaultResolverWithParameters() {
+        final ServiceIdResolver resolver = new DefaultServiceIdResolver();
+        final String serviceId = resolver.resolve(HttpMethod.GET, "/some/path/{with}/{multiple}/parameters", new Operation());
+
+        assertEquals("GET_some_path_with_multiple_parameters", serviceId);
+    }
+
+    @Test
+    public void testDefaultResolverParameterWithDash() {
+        final ServiceIdResolver resolver = new DefaultServiceIdResolver();
+        final String serviceId = resolver.resolve(HttpMethod.GET, "/some/path/{with-dash}/parameter", new Operation());
+
+        assertEquals("GET_some_path_with_dash_parameter", serviceId);
+    }
+
+    @Test
+    public void testOperationIdResolver() {
+        final ServiceIdResolver resolver = new OperationIdServiceIdResolver();
+        final String serviceId = resolver.resolve(HttpMethod.GET, "/some/path", new Operation().operationId("testOperationIdResolver"));
+
+        assertEquals("testOperationIdResolver", serviceId);
+    }
+
+    @Test
+    public void testOperationIdResolverFallback() {
+        final ServiceIdResolver resolver = new OperationIdServiceIdResolver();
+        final String serviceId = resolver.resolve(HttpMethod.GET, "/some/path/{with}/{multiple}/parameters/fallback", new Operation());
+
+        assertEquals("GET_some_path_with_multiple_parameters_fallback", serviceId);
+    }
+}


### PR DESCRIPTION
* Created `ServiceIdResolver` interface which is used to implement a resolver to compute service ID
* Moved existing method `computeServiceId` into a separate class `DefaultServiceIdResolver`
* Created `OperationIdServiceIdResolver` which tries to use the value of `operationId` property in Swagger file and falls back to `DefaultServiceIdResolver` if no `operationId` provided.