### PR TITLE
Respect basePath of Swagger API spec.

### DIFF
--- a/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/SwaggerRouter.java
+++ b/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/SwaggerRouter.java
@@ -71,13 +71,21 @@ public class SwaggerRouter {
 
     public static Router swaggerRouter(Router baseRouter, Swagger swagger, EventBus eventBus, ServiceIdResolver serviceIdResolver, Function<RoutingContext, DeliveryOptions> configureMessage) {
         baseRouter.route().handler(BodyHandler.create());
+        final String basePath = getBasePath(swagger);
         swagger.getPaths().forEach((path, pathDescription) -> pathDescription.getOperationMap().forEach((method, operation) -> {
-            Route route = ROUTE_BUILDERS.get(method).buildRoute(baseRouter, convertParametersToVertx(path));
+            Route route = ROUTE_BUILDERS.get(method).buildRoute(baseRouter, convertParametersToVertx(basePath + path));
             String serviceId = serviceIdResolver.resolve(method, path, operation);
             configureRoute(route, serviceId, operation, eventBus, configureMessage);
         }));
 
         return baseRouter;
+    }
+
+    private static String getBasePath(Swagger swagger) {
+        String result = swagger.getBasePath();
+        if (result == null)
+            result = "";
+        return result;
     }
 
     private static void configureRoute(Route route, String serviceId, Operation operation, EventBus eventBus, Function<RoutingContext, DeliveryOptions> configureMessage) {

--- a/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/BuildRouterTest.java
+++ b/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/BuildRouterTest.java
@@ -189,7 +189,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testResourceNotfound(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/dummy", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/dummy", response -> {
             context.assertEquals(response.statusCode(), 404);
             async.complete();
         });
@@ -199,7 +199,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testMessageIsConsume(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/store/inventory", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/store/inventory", response -> {
             response.bodyHandler(body -> {
                 JsonObject jsonBody = new JsonObject(body.toString(Charset.forName("utf-8")));
                 context.assertTrue(jsonBody.containsKey("sold"));
@@ -212,7 +212,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000, expected = TimeoutException.class)
     public void testMessageIsNotConsume(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/logout", response -> response.exceptionHandler(err -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/logout", response -> response.exceptionHandler(err -> {
             async.complete();
         }));
     }
@@ -220,7 +220,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithPathParameter(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/5", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/5", response -> {
             response.bodyHandler(body -> {
                 JsonObject jsonBody = new JsonObject(body.toString(Charset.forName("utf-8")));
                 context.assertTrue(jsonBody.containsKey("petId_received"));
@@ -233,7 +233,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithQuerySimpleParameter(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/login?username=myUser&password=mySecret", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/login?username=myUser&password=mySecret", response -> {
             response.bodyHandler(body -> {
                 JsonObject jsonBody = new JsonObject(body.toString(Charset.forName("utf-8")));
                 context.assertTrue(jsonBody.containsKey("username_received"));
@@ -246,7 +246,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithQueryArrayParameter(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/findByStatus?status=available", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/findByStatus?status=available", response -> {
             response.bodyHandler(body -> {
                 JsonArray jsonArray = new JsonArray(body.toString(Charset.forName("utf-8")));
                 context.assertTrue(jsonArray.size() == 1);
@@ -264,7 +264,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithQueryManyArrayParameter(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/findByStatus?status=available&status=pending", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/findByStatus?status=available&status=pending", response -> {
             response.bodyHandler(body -> {
                 JsonArray jsonArray = new JsonArray(body.toString(Charset.forName("utf-8")));
                 context.assertTrue(jsonArray.size() == 2);
@@ -285,7 +285,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithBodyParameterNoBody(TestContext context) {
         Async async = context.async();
-        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/user/createWithArray");
+        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/v2/user/createWithArray");
         req.handler(response -> {
             context.assertEquals(response.statusCode(), 400);
             async.complete();
@@ -298,7 +298,7 @@ public class BuildRouterTest {
         User user1 = new User(1L, "user 1", "first 1", "last 1", "email 1", "secret 1", "phone 1", 1);
         User user2 = new User(2L, "user 2", "first 2", "last 2", "email 2", "secret 2", "phone 2", 2);
         JsonArray users = new JsonArray(Arrays.asList(user1, user2));
-        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/user/createWithArray");
+        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/v2/user/createWithArray");
         req.setChunked(true);
         req.handler(response -> response.bodyHandler(result -> {
             JsonObject jsonBody = new JsonObject(result.toString(Charset.forName("utf-8")));
@@ -313,7 +313,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testNullBodyResponse(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/logout", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/logout", response -> {
             context.assertEquals(response.statusCode(), 200);
             async.complete();
         });
@@ -322,7 +322,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithFormParameterMultiPart(TestContext context) {
         Async async = context.async();
-        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/pet/1/uploadImage");
+        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/v2/pet/1/uploadImage");
         req.setChunked(false);
         req.handler(response -> response.bodyHandler(result -> {
             JsonObject jsonBody = new JsonObject(result.toString(Charset.forName("utf-8")));
@@ -365,7 +365,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithFormParameterUrlEncoded(TestContext context) {
         Async async = context.async();
-        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/pet/1");
+        HttpClientRequest req = httpClient.post(TEST_PORT, TEST_HOST, "/v2/pet/1");
 
         req.handler(response -> response.bodyHandler(result -> {
             JsonObject jsonBody = new JsonObject(result.toString(Charset.forName("utf-8")));
@@ -391,7 +391,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithHeaderParameter(TestContext context) {
         Async async = context.async();
-        HttpClientRequest req = httpClient.delete(TEST_PORT, TEST_HOST, "/pet/1");
+        HttpClientRequest req = httpClient.delete(TEST_PORT, TEST_HOST, "/v2/pet/1");
         req.putHeader("api_key", "MyAPIKey");
         req.handler(response -> response.bodyHandler(result -> {
             JsonObject jsonBody = new JsonObject(result.toString(Charset.forName("utf-8")));
@@ -408,7 +408,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithCustomStatusCode(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/statusCode", response -> { 
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/statusCode", response -> {
             context.assertEquals(206, response.statusCode());
             String header = response.getHeader(SwaggerRouter.CUSTOM_STATUS_CODE_HEADER_KEY);
             context.assertNull(header);
@@ -419,7 +419,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithCustomStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/statusMessage", response -> { 
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/statusMessage", response -> {
             context.assertEquals("My Custom Message", response.statusMessage());
             async.complete();
         });
@@ -428,7 +428,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithCustomStatusCodeAndMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/statusCodeAndMessage", response -> { 
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/statusCodeAndMessage", response -> {
             context.assertEquals(206, response.statusCode());
             context.assertEquals("My Custom Message", response.statusMessage());
             async.complete();
@@ -438,7 +438,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithSimpleReturnedHeader(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/simpleHeader", response -> { 
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/simpleHeader", response -> {
             String header = response.getHeader("Header_KEY");
             context.assertNotNull(header);
             context.assertEquals("Header_VALUE", header);
@@ -449,7 +449,7 @@ public class BuildRouterTest {
     @Test(timeout = 2000)
     public void testWithSimpleReturnedHeaderAndCustomStatusCode(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/simpleHeaderAndStatusCode", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/simpleHeaderAndStatusCode", response -> {
             context.assertEquals(206, response.statusCode());
             String header = response.getHeader("Header_KEY");
             context.assertNotNull(header);

--- a/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/ErrorHandlingTest.java
+++ b/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/ErrorHandlingTest.java
@@ -102,7 +102,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testStatusCodeAndStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/store/inventory", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/store/inventory", response -> {
             response.bodyHandler(body -> {
                 context.assertEquals(response.statusCode(), EXISTING_HTTP_STATUS_CODE);
                 context.assertEquals(response.statusMessage(), ERROR_CUSTOM_MESSAGE);
@@ -114,7 +114,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testStatusCodeAndNullStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/store/order/1", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/store/order/1", response -> {
             context.assertEquals(response.statusCode(), EXISTING_HTTP_STATUS_CODE);
             context.assertEquals(response.statusMessage(), HttpResponseStatus.valueOf(EXISTING_HTTP_STATUS_CODE).reasonPhrase());
             async.complete();
@@ -124,7 +124,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testStatusCodeAndEmptyStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.delete(TEST_PORT, TEST_HOST, "/store/order/1", response -> {
+        httpClient.delete(TEST_PORT, TEST_HOST, "/v2/store/order/1", response -> {
             context.assertEquals(response.statusCode(), EXISTING_HTTP_STATUS_CODE);
             context.assertEquals(response.statusMessage(), HttpResponseStatus.valueOf(EXISTING_HTTP_STATUS_CODE).reasonPhrase());
             async.complete();
@@ -134,7 +134,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testInexistingStatusCodeAndStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/5", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/5", response -> {
             response.bodyHandler(body -> {
                 context.assertEquals(response.statusCode(), NOT_EXISTING_HTTP_STATUS_CODE);
                 context.assertEquals(response.statusMessage(), ERROR_CUSTOM_MESSAGE);
@@ -146,7 +146,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testInexistingStatusCodeAndNullStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.post(TEST_PORT, TEST_HOST, "/pet/1", response -> response.bodyHandler(result -> {
+        httpClient.post(TEST_PORT, TEST_HOST, "/v2/pet/1", response -> response.bodyHandler(result -> {
             context.assertEquals(response.statusCode(), NOT_EXISTING_HTTP_STATUS_CODE);
             context.assertEquals(response.statusMessage(), NOT_EXISTING_HTTP_STATUS_MESSAGE);
             async.complete();
@@ -156,7 +156,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testInexistingStatusCodeAndEmptyStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.delete(TEST_PORT, TEST_HOST, "/pet/1", response -> response.bodyHandler(result -> {
+        httpClient.delete(TEST_PORT, TEST_HOST, "/v2/pet/1", response -> response.bodyHandler(result -> {
             context.assertEquals(response.statusCode(), NOT_EXISTING_HTTP_STATUS_CODE);
             context.assertEquals(response.statusMessage(), NOT_EXISTING_HTTP_STATUS_MESSAGE);
             async.complete();
@@ -167,7 +167,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testInvalidStatusCodeAndStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.post(TEST_PORT, TEST_HOST, "/pet/1/uploadImage", response -> response.bodyHandler(result -> {
+        httpClient.post(TEST_PORT, TEST_HOST, "/v2/pet/1/uploadImage", response -> response.bodyHandler(result -> {
             context.assertEquals(response.statusCode(), DEFAULT_HTTP_STATUS_CODE);
             context.assertEquals(response.statusMessage(), HttpResponseStatus.valueOf(DEFAULT_HTTP_STATUS_CODE).reasonPhrase());
             async.complete();
@@ -177,7 +177,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testInvalidStatusCodeAndNullStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/user/login?username=myUser&password=mySecret", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/user/login?username=myUser&password=mySecret", response -> {
             response.bodyHandler(body -> {
                 context.assertEquals(response.statusCode(), DEFAULT_HTTP_STATUS_CODE);
                 context.assertEquals(response.statusMessage(), HttpResponseStatus.valueOf(DEFAULT_HTTP_STATUS_CODE).reasonPhrase());
@@ -189,7 +189,7 @@ public class ErrorHandlingTest {
     @Test(timeout = 2000)
     public void testInvalidStatusCodeAndEmptyStatusMessage(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/findByStatus?status=available", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/findByStatus?status=available", response -> {
             response.bodyHandler(body -> {
                 context.assertEquals(response.statusCode(), DEFAULT_HTTP_STATUS_CODE);
                 context.assertEquals(response.statusMessage(), HttpResponseStatus.valueOf(DEFAULT_HTTP_STATUS_CODE).reasonPhrase());

--- a/sample/petstore-vertx-server/src/test/java/io/swagger/server/api/PetStoreTest.java
+++ b/sample/petstore-vertx-server/src/test/java/io/swagger/server/api/PetStoreTest.java
@@ -71,7 +71,7 @@ public class PetStoreTest {
     @Test(timeout = 2000)
     public void testFindByStatus(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/findByStatus?status=available", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/findByStatus?status=available", response -> {
             response.bodyHandler(body -> {
                 JsonArray jsonArray = new JsonArray(body.toString());
                 context.assertTrue(jsonArray.size() == 1);
@@ -92,7 +92,7 @@ public class PetStoreTest {
     @Test(timeout = 2000)
     public void testGetPetById(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/1", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/1", response -> {
             response.bodyHandler(body -> {
                 JsonObject jsonObject = new JsonObject(body.toString());
                 try {
@@ -112,7 +112,7 @@ public class PetStoreTest {
     @Test(timeout = 2000)
     public void testGetPetByIdPetNotFound(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/3", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/3", response -> {
             response.bodyHandler(body -> {
                 context.assertEquals(response.statusCode(), PetApiException.Pet_getPetById_404_Exception.getStatusCode());
                 context.assertEquals(response.statusMessage(), PetApiException.Pet_getPetById_404_Exception.getStatusMessage());
@@ -124,7 +124,7 @@ public class PetStoreTest {
     @Test(timeout = 2000)
     public void testGetPetByIdInternalServerError(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/pet/2", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/pet/2", response -> {
             response.bodyHandler(body -> {
                 context.assertEquals(response.statusCode(), MainApiException.INTERNAL_SERVER_ERROR.getStatusCode());
                 context.assertEquals(response.statusMessage(), MainApiException.INTERNAL_SERVER_ERROR.getStatusMessage());
@@ -136,7 +136,7 @@ public class PetStoreTest {
     @Test(timeout = 2000)
     public void testGetOrderById(TestContext context) {
         Async async = context.async();
-        httpClient.getNow(TEST_PORT, TEST_HOST, "/store/order/1", response -> {
+        httpClient.getNow(TEST_PORT, TEST_HOST, "/v2/store/order/1", response -> {
             response.bodyHandler(body -> {
                 JsonObject jsonObject = new JsonObject(body.toString());
                 try {


### PR DESCRIPTION
- Swagger allows to define a basePath in the yaml/JSON file. If it is
  present, we must respect it.
- Change Router to serve endpoints under the basepath, if present.