### PR TITLE
#63 - MainApiException extend RuntimeException instead

### DIFF
--- a/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/MainApiException.mustache
+++ b/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/MainApiException.mustache
@@ -1,6 +1,6 @@
 package {{invokerPackage}};
 
-public class MainApiException extends Exception {
+public class MainApiException extends RuntimeException {
     private int statusCode;
     private String statusMessage;
 


### PR DESCRIPTION
MainApiException extending RuntimeException instead of Exception.

This makes them possible to use directly within RxJava operations, instead of having to wrap them into a unchecked exception before throwing.

