### PR TITLE
Fixing #78

### DIFF
--- a/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/apiVerticle.mustache
+++ b/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/apiVerticle.mustache
@@ -45,7 +45,15 @@ public class {{classname}}Verticle extends AbstractVerticle {
                                 {{#isString}}
                                     {{#vendorExtensions}}
                                         {{#X-isUUID}}
+                                            {{#required}}
                 {{{dataType}}} {{paramName}} = {{{dataType}}}.fromString(message.body().getString("{{baseName}}"));
+                                            {{/required}}
+                                            {{^required}}
+                {{{dataType}}} {{paramName}} = null;
+                if(message.body().getString("{{baseName}}") != null) {
+                    {{paramName}} = {{{dataType}}}.fromString(message.body().getString("{{baseName}}"));
+                }
+                                            {{/required}}
                                         {{/X-isUUID}}
                                         {{^X-isUUID}}
                 {{{dataType}}} {{paramName}} = message.body().getString("{{baseName}}");
@@ -56,7 +64,15 @@ public class {{classname}}Verticle extends AbstractVerticle {
                                     {{/vendorExtensions}}
                                 {{/isString}}
                                 {{^isString}}
+                                    {{#required}}
                 {{{dataType}}} {{paramName}} = Json.mapper.readValue(message.body().getString("{{baseName}}"), {{{dataType}}}.class);
+                                    {{/required}}
+                                    {{^required}}
+                {{{dataType}}} {{paramName}} = null;
+                if(message.body().getString("{{baseName}}") != null) {
+                    {{paramName}} = Json.mapper.readValue(message.body().getString("{{baseName}}"), {{{dataType}}}.class);
+                }
+                                    {{/required}}
                                 {{/isString}}
                             {{/isPrimitiveType}}
                             {{^isPrimitiveType}}

--- a/modules/vertx-swagger-codegen/src/test/java/com/github/phiz71/vertx/swagger/codegen/SampleVertXGeneratorTest.java
+++ b/modules/vertx-swagger-codegen/src/test/java/com/github/phiz71/vertx/swagger/codegen/SampleVertXGeneratorTest.java
@@ -145,4 +145,26 @@ public class SampleVertXGeneratorTest {
 
         FileUtils.deleteDirectory(new File("temp"));
     }
+
+    @Test
+    public void testDefaultValue() throws IOException {
+        String[] args = new String[7];
+        args[0] = "generate";
+        args[1] = "-l";
+        args[2] = "java-vertx";
+        args[3] = "-i";
+        args[4] = "testDefaultValue.json";
+        args[5] = "-o";
+        args[6] = "temp/test-server";
+        SwaggerCodegen.main(args);
+
+        File testApiVerticleFile = new File(
+            "temp/test-server/src/main/java/io/swagger/server/api/verticle/TestApiVerticle.java");
+
+        Assert.assertTrue(FileUtils.readFileToString(testApiVerticleFile).contains("BigDecimal customValue = null;"));
+        Assert.assertTrue(FileUtils.readFileToString(testApiVerticleFile).contains("if(message.body().getString(\"customValue\") != null) {"));
+        Assert.assertTrue(FileUtils.readFileToString(testApiVerticleFile).contains("customValue = Json.mapper.readValue(message.body().getString(\"customValue\"), BigDecimal.class);"));
+
+        FileUtils.deleteDirectory(new File("temp"));
+    }
 }

--- a/modules/vertx-swagger-codegen/src/test/resources/testDefaultValue.json
+++ b/modules/vertx-swagger-codegen/src/test/resources/testDefaultValue.json
@@ -1,0 +1,40 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "test default value of parameters"
+    },
+    "host": "localhost",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/defaultValue": {
+            "get": {
+                "tags": [
+                    "Test"
+                ],
+                "summary": "test default value",
+                "operationId": "getDefaultValue",
+                "parameters": [
+                    {
+                        "name": "customValue",
+                        "in": "query",
+                        "type": "number",
+                        "format": "int32",
+                        "required": false,
+                        "default": 0
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "schema":{
+                            "type":"string"
+                        },
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/extractors/AbstractSerializableParameterExtractor.java
+++ b/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/extractors/AbstractSerializableParameterExtractor.java
@@ -1,5 +1,6 @@
 package com.github.phiz71.vertx.swagger.router.extractors;
 
+import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.SerializableParameter;
 import io.vertx.core.MultiMap;
@@ -13,27 +14,29 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractSerializableParameterExtractor {
     public Object extract(String name, Parameter parameter, MultiMap params) {
-        SerializableParameter serializableParam = (SerializableParameter) parameter;
+        AbstractSerializableParameter abstractSerializableParameter = (AbstractSerializableParameter) parameter;
         if (!params.contains(name)) {
-            if (serializableParam.getRequired()) {
+            if (abstractSerializableParameter.getRequired()) {
                 throw new IllegalArgumentException("Missing required parameter: " + name);
+            } else if (abstractSerializableParameter.getDefaultValue()!=null){
+                return abstractSerializableParameter.getDefaultValue();
             } else {
                 return null;
             }
         }
 
-        if ((serializableParam.getAllowEmptyValue() == null
-                || !serializableParam.getAllowEmptyValue())
+        if ((abstractSerializableParameter.getAllowEmptyValue() == null
+                || !abstractSerializableParameter.getAllowEmptyValue())
                 && StringUtils.isEmpty(params.get(name))) {
             throw new IllegalArgumentException(
                     "Empty value is not authorized for parameter: " + name);
         }
 
-        if ("array".equals(serializableParam.getType())) {
-            if ("multi".equals(serializableParam.getCollectionFormat())) {
+        if ("array".equals(abstractSerializableParameter.getType())) {
+            if ("multi".equals(abstractSerializableParameter.getCollectionFormat())) {
                 return params.getAll(name);
             } else {
-                List<String> resultParams = this.splitArrayParam(serializableParam,
+                List<String> resultParams = this.splitArrayParam(abstractSerializableParameter,
                         params.get(name));
                 if (resultParams != null) {
                     return resultParams;

--- a/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/extractors/QueryParameterExtractorTest.java
+++ b/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/extractors/QueryParameterExtractorTest.java
@@ -88,6 +88,9 @@ public class QueryParameterExtractorTest {
         eventBus.<JsonObject> consumer("GET_query_simple_not_required").handler(message -> {
             message.reply(message.body().getString("queryNotRequired"));
         });
+        eventBus.<JsonObject> consumer("GET_query_simple_not_required_withdefault").handler(message -> {
+            message.reply(message.body().getString("queryNotRequired"));
+        });
         // init http client
         httpClient = Vertx.vertx().createHttpClient();
 
@@ -246,7 +249,32 @@ public class QueryParameterExtractorTest {
             });
         }).end();
     }
-    
+
+    @Test()
+    public void testOkQuerySimpleNotRequiredWithDefaultWithParam(TestContext context) {
+        Async async = context.async();
+        HttpClientRequest req = httpClient.get(TEST_PORT, TEST_HOST, "/query/simple/not/required/withdefault?queryNotRequired=foo");
+        req.handler(response -> {
+            response.bodyHandler(body -> {
+                context.assertEquals(response.statusCode(), 200);
+                context.assertEquals("foo", body.toString());
+                async.complete();
+            });
+        }).end();
+    }
+
+    @Test()
+    public void testOkQuerySimpleNotRequiredWithDefaultWithoutParam(TestContext context) {
+        Async async = context.async();
+        HttpClientRequest req = httpClient.get(TEST_PORT, TEST_HOST, "/query/simple/not/required/withdefault");
+        req.handler(response -> {
+            response.bodyHandler(body -> {
+                context.assertEquals(response.statusCode(), 200);
+                context.assertEquals("defaultValue", body.toString());
+                async.complete();
+            });
+        }).end();
+    }
 
     @AfterClass
     public static void afterClass(TestContext context) {

--- a/modules/vertx-swagger-router/src/test/resources/extractors/swaggerQueryExtractor.json
+++ b/modules/vertx-swagger-router/src/test/resources/extractors/swaggerQueryExtractor.json
@@ -202,6 +202,26 @@
           }
         }
       }
+    },
+    "/query/simple/not/required/withdefault": {
+      "get": {
+        "description": "service where query param is not a required string but has a default value",
+        "parameters": [
+          {
+            "name": "queryNotRequired",
+            "in": "query",
+            "required": false,
+            "default": "defaultValue",
+            "description": "not a required param but with a default value",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Use default value of parameters when provided.
Consider the "required" field of a parameter to change the way the Verticle is generated.