### PR TITLE
Support vertx-web 3.5

### DIFF
--- a/modules/vertx-swagger-router/pom.xml
+++ b/modules/vertx-swagger-router/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <vertx.version>3.4.2</vertx.version>
+    <vertx.version>3.5.0</vertx.version>
     <swagger-parser.version>1.0.26</swagger-parser.version>
   </properties>
 

--- a/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/auth/ApiKeyAuthHandler.java
+++ b/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/auth/ApiKeyAuthHandler.java
@@ -1,5 +1,8 @@
 package com.github.phiz71.vertx.swagger.router.auth;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
@@ -8,6 +11,8 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.AuthHandler;
 import io.vertx.ext.web.handler.impl.AuthHandlerImpl;
+
+import java.util.Optional;
 
 import static com.github.phiz71.vertx.swagger.router.auth.ApiKeyAuthHandler.Location.HEADER;
 import static com.github.phiz71.vertx.swagger.router.auth.ApiKeyAuthHandler.Location.QUERY;
@@ -19,6 +24,30 @@ public class ApiKeyAuthHandler extends AuthHandlerImpl {
 
     private final String name;
     private final ApiKeyAuthHandler.Location location;
+
+    @Override
+    public void parseCredentials(RoutingContext context, Handler<AsyncResult<JsonObject>> handler) {
+        HttpServerRequest request = context.request();
+
+        String value = null;
+        switch (this.location) {
+            case QUERY:
+                value = request.getParam(this.name);
+                break;
+            case HEADER:
+                value = request.headers().get(this.name);
+                break;
+            default:
+                context.fail(401);
+                return;
+        }
+
+        JsonObject authInfo = new JsonObject()
+                .put(API_KEY_NAME_PARAM, this.name)
+                .put(API_KEY_VALUE_PARAM, value);
+
+        handler.handle(Future.succeededFuture(authInfo));
+    }
 
     public enum Location {
         HEADER, QUERY;
@@ -36,43 +65,5 @@ public class ApiKeyAuthHandler extends AuthHandlerImpl {
         this.name = name;
     }
 
-    public void handle(RoutingContext context) {
-        User user = context.user();
-        if (user != null) {
-            this.authorise(user, context);
-        } else {
-            HttpServerRequest request = context.request();
 
-            String value = null;
-            switch (this.location) {
-                case QUERY:
-                    value = request.getParam(this.name);
-                    break;
-                case HEADER:
-                    value = request.headers().get(this.name);
-                    break;
-                default:
-                    context.fail(401);
-                    return;
-            }
-
-            JsonObject authInfo = new JsonObject().put(API_KEY_NAME_PARAM, this.name)
-                    .put(API_KEY_VALUE_PARAM, value);
-            
-            this.authProvider.authenticate(authInfo, res -> {
-                if (res.succeeded()) {
-                    User authenticated = res.result();
-                    context.setUser(authenticated);
-                    Session session = context.session();
-                    if (session != null) {
-                        session.regenerateId();
-                    }
-                    this.authorise(authenticated, context);
-                } else {
-                    context.fail(401);
-                }
-            });
-        }
-
-    }
 }

--- a/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/auth/InterceptableRoutingContext.java
+++ b/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/auth/InterceptableRoutingContext.java
@@ -1,6 +1,7 @@
 package com.github.phiz71.vertx.swagger.router.auth;
 
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -295,5 +296,15 @@ public class InterceptableRoutingContext implements RoutingContext {
     @Override
     public String pathParam(String name) {
         return this.inner.pathParam(name);
+    }
+
+    @Override
+    public MultiMap queryParams() {
+        return this.inner.queryParams();
+    }
+
+    @Override
+    public List<String> queryParam(String s) {
+        return this.inner.queryParam(s);
     }
 }

--- a/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/auth/SwaggerAuthHandlerFactory.java
+++ b/modules/vertx-swagger-router/src/main/java/com/github/phiz71/vertx/swagger/router/auth/SwaggerAuthHandlerFactory.java
@@ -4,9 +4,13 @@ import com.github.phiz71.vertx.swagger.router.SwaggerRouter;
 import com.github.phiz71.vertx.swagger.router.auth.ApiKeyAuthHandler.Location;
 import io.swagger.models.auth.ApiKeyAuthDefinition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.AuthHandler;
 import io.vertx.ext.web.handler.BasicAuthHandler;
@@ -86,6 +90,16 @@ public class SwaggerAuthHandlerFactory {
                 return this;
             }
 
+            @Override
+            public void parseCredentials(RoutingContext routingContext, Handler<AsyncResult<JsonObject>> handler) {
+
+            }
+
+            @Override
+            public void authorize(User user, Handler<AsyncResult<Void>> handler) {
+
+            }
+
             private void handle(InterceptableRoutingContext context, int orLevelIndex, int andLevelIndex) {
                 // reset context
                 context.clearUser();
@@ -119,6 +133,7 @@ public class SwaggerAuthHandlerFactory {
                 }
             }
 
+            @Override
             public void handle(RoutingContext context) {
                 handle(new InterceptableRoutingContext(context), 0, 0);
             }

--- a/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/auth/InterceptableRoutingContextImplTest.java
+++ b/modules/vertx-swagger-router/src/test/java/com/github/phiz71/vertx/swagger/router/auth/InterceptableRoutingContextImplTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.util.HashSet;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 public class InterceptableRoutingContextImplTest {
@@ -292,6 +293,12 @@ class TestHttpServerRequest implements HttpServerRequest {
     }
 
     @Override
+    public SSLSession sslSession() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
     public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
         // TODO Auto-generated method stub
         return null;
@@ -299,6 +306,12 @@ class TestHttpServerRequest implements HttpServerRequest {
 
     @Override
     public String absoluteURI() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public HttpServerRequest bodyHandler(Handler<Buffer> bodyHandler) {
         // TODO Auto-generated method stub
         return null;
     }


### PR DESCRIPTION
I run into a problem in the `ApiKeyAuthHandler` using vertx-swagger with vertx 3.5 being caused by the changes in the interfaces of some classes.
This updates the project to use vertx 3.5 and also modifies `ApiKeyAuthHandler` and code to adhere to the new interfaces