### PR TITLE
Fixes Issue #93 - File upload not working

### DIFF
--- a/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/apiVerticle.mustache
+++ b/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/apiVerticle.mustache
@@ -70,7 +70,12 @@ public class {{classname}}Verticle extends AbstractVerticle {
                     {{/isString}}
                 {{/isPrimitiveType}}
                 {{^isPrimitiveType}}
+                    {{#isFile}}
+            {{{dataType}}} {{paramName}} = new {{{dataType}}}(message.body().getString("{{baseName}}"));
+                    {{/isFile}}
+                    {{^isFile}}
             {{{dataType}}} {{paramName}} = Json.mapper.readValue(message.body().getJsonObject("{{baseName}}").encode(), {{{dataType}}}.class);
+                    {{/isFile}}
                 {{/isPrimitiveType}}
             {{/isListContainer}}
         {{/allParams}}

--- a/modules/vertx-swagger-codegen/src/test/java/com/github/phiz71/vertx/swagger/codegen/SampleVertXGeneratorTest.java
+++ b/modules/vertx-swagger-codegen/src/test/java/com/github/phiz71/vertx/swagger/codegen/SampleVertXGeneratorTest.java
@@ -183,6 +183,30 @@ public class SampleVertXGeneratorTest {
     }
 
     @Test
+    public void testFile() throws IOException {
+        String[] args = new String[7];
+        args[0] = "generate";
+        args[1] = "-l";
+        args[2] = "java-vertx";
+        args[3] = "-i";
+        args[4] = "testFile.json";
+        args[5] = "-o";
+        args[6] = "temp/test-server";
+        SwaggerCodegen.main(args);
+
+        File testApiVerticleFile = new File(
+                "temp/test-server/src/main/java/io/swagger/server/api/verticle/TestApiVerticle.java");
+
+        Assert.assertTrue(FileUtils.readFileToString(testApiVerticleFile).contains(
+                "File file = new File(message.body().getString(\"file\"));"));
+
+        Assert.assertFalse(FileUtils.readFileToString(testApiVerticleFile).contains(
+                "File file = Json.mapper.readValue(message.body().getJsonObject(\"file\").encode(), File.class);"));
+
+        FileUtils.deleteDirectory(new File("temp"));
+    }
+
+    @Test
     public void testImplGenWithoutImplDefault() throws IOException {
         String[] args = new String[7];
         args[0] = "generate";

--- a/modules/vertx-swagger-codegen/src/test/resources/testFile.json
+++ b/modules/vertx-swagger-codegen/src/test/resources/testFile.json
@@ -1,0 +1,45 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "test MainApiVerticle option"
+    },
+    "host": "localhost",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/file/{originalFileName}": {
+            "post": {
+                "tags": [
+                    "Test"
+                ],
+                "summary": "test generator options",
+                "operationId": "dummy",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "file",
+                        "in": "formData",
+                        "description": "file to upload",
+                        "required": false,
+                        "type": "file"
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "schema":{
+                            "type":"string"
+                        },
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sample/petstore-vertx-rx-server/src/main/java/io/swagger/server/api/verticle/PetApiVerticle.java
+++ b/sample/petstore-vertx-rx-server/src/main/java/io/swagger/server/api/verticle/PetApiVerticle.java
@@ -142,7 +142,7 @@ public class PetApiVerticle extends AbstractVerticle {
             User user = SwaggerRouter.extractAuthUserFromMessage(message);
             Long petId = Json.mapper.readValue(message.body().getString("petId"), Long.class);
             String additionalMetadata = message.body().getString("additionalMetadata");
-            File file = Json.mapper.readValue(message.body().getJsonObject("file").encode(), File.class);
+            File file = new File(message.body().getString("file"));
             service.uploadFile(petId, additionalMetadata, file, io.vertx.rxjava.ext.auth.User.newInstance(user)).subscribe(
                 verticleHelper.getRxResultHandler(message, true, new TypeReference<ModelApiResponse>(){}),
                 verticleHelper.getErrorAction(message, UPLOADFILE_SERVICE_ID)

--- a/sample/petstore-vertx-server/src/main/java/io/swagger/server/api/verticle/PetApiVerticle.java
+++ b/sample/petstore-vertx-server/src/main/java/io/swagger/server/api/verticle/PetApiVerticle.java
@@ -128,7 +128,7 @@ public class PetApiVerticle extends AbstractVerticle {
             User user = SwaggerRouter.extractAuthUserFromMessage(message);
             Long petId = Json.mapper.readValue(message.body().getString("petId"), Long.class);
             String additionalMetadata = message.body().getString("additionalMetadata");
-            File file = Json.mapper.readValue(message.body().getJsonObject("file").encode(), File.class);
+            File file = new File(message.body().getString("file"));
             service.uploadFile(petId, additionalMetadata, file, user, verticleHelper.getAsyncResultHandler(message, UPLOADFILE_SERVICE_ID, true, new TypeReference<ModelApiResponse>(){}));
 
         } catch (Exception e) {


### PR DESCRIPTION
Generated Verticle now creates a `File` object from the `message.body().getString("file")`.
Adds a test for this case. 