### PR TITLE
#106 To fix duplicate default constructors for top level definition of array type

### DIFF
--- a/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/pojo.mustache
+++ b/modules/vertx-swagger-codegen/src/main/resources/javaVertXServer/pojo.mustache
@@ -11,11 +11,11 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   }
 
-  public {{classname}} ({{#vars}}{{{datatypeWithEnum}}} {{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}) {
-    {{#vars}}
+  {{#vars}}
+  public {{classname}} ({{{datatypeWithEnum}}} {{name}}{{#hasMore}}, {{/hasMore}}) {
     this.{{name}} = {{name}};
-    {{/vars}}
   }
+  {{/vars}}
 
   {{#vars}}
     {{#vendorExtensions.extraAnnotation}}{{vendorExtensions.extraAnnotation}}{{/vendorExtensions.extraAnnotation}}

--- a/modules/vertx-swagger-codegen/src/test/java/com/github/phiz71/vertx/swagger/codegen/SampleVertXGeneratorTest.java
+++ b/modules/vertx-swagger-codegen/src/test/java/com/github/phiz71/vertx/swagger/codegen/SampleVertXGeneratorTest.java
@@ -2,6 +2,7 @@ package com.github.phiz71.vertx.swagger.codegen;
 
 import io.swagger.codegen.SwaggerCodegen;
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -157,6 +158,31 @@ public class SampleVertXGeneratorTest {
 
         Assert.assertTrue(FileUtils.readFileToString(testApiVerticleFile).contains(
                 "List<String> updateModel = Json.mapper.readValue(message.body().getJsonArray(\"updateModel\").encode(), new TypeReference<List<String>>(){});"));
+
+        FileUtils.deleteDirectory(new File("temp"));
+    }
+
+    @Test
+    public void testStringArray() throws IOException {
+        String[] args = new String[7];
+        args[0] = "generate";
+        args[1] = "-l";
+        args[2] = "java-vertx";
+        args[3] = "-i";
+        args[4] = "testStringArray.json";
+        args[5] = "-o";
+        args[6] = "temp/test-server";
+        SwaggerCodegen.main(args);
+
+        File testApiVerticleFile = new File(
+                "temp/test-server/src/main/java/io/swagger/server/api/model/StringArray.java");
+
+        String generated = FileUtils.readFileToString(testApiVerticleFile);
+        int firstDefaultConstructorIndex = generated.indexOf("public StringArray () {");
+        Assert.assertThat(firstDefaultConstructorIndex, Matchers.greaterThan(0));
+        int secondDefaultConstructorIndex = generated.indexOf("public StringArray () {",
+                firstDefaultConstructorIndex + 1);
+        Assert.assertEquals(-1, secondDefaultConstructorIndex);
 
         FileUtils.deleteDirectory(new File("temp"));
     }

--- a/modules/vertx-swagger-codegen/src/test/resources/testStringArray.json
+++ b/modules/vertx-swagger-codegen/src/test/resources/testStringArray.json
@@ -1,0 +1,38 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "test MainApiVerticle option"
+    },
+    "host": "localhost",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/stringArray": {
+            "get": {
+                "tags": [
+                    "Test"
+                ],
+                "summary": "test string array response",
+                "operationId": "dummy",
+                "responses": {
+                    "default": {
+                        "description" : "OK",
+                        "schema" : {
+                            "$ref" : "#/definitions/StringArray"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "StringArray" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed pojo.mustache to generate constructor with arguments only when #vars condition is met.